### PR TITLE
Add python version requirement.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+[options]
+python_requires = >= 3


### PR DESCRIPTION
Currently one can install this using `pip install -e .` in a Python 2 environment, which succeeds.  However, trying to run the program in a Python 2 environment via `python -m workout examples/easy.yaml` results in errors:
```
$ python -m workout examples/easy.yaml 

Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 163, in _run_module_as_main
    mod_name, _Error)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 111, in _get_module_details
    __import__(mod_name)  # Do not catch exceptions initializing package
  File "workout/__init__.py", line 5, in <module>
    from .workouts import workout
  File "workout/workouts.py", line 26
    display(f'\nrunning workout: "{self.name}" with sections:')
```

This change creates the requirement to use python 3 or better during pip install step, reducing confusion for those who have lower versions of python as the default (e.g. all OSX users) due to errors after a successful install.  With the changes, if the `pip install -e .` command is run, error output is produced letting the user know Python >=3 is required:
```
$ pip install -e .
[...]
Obtaining file:///Users/xxxx/python_projects/Script_My_Workout
ERROR: Package 'workout' requires a different Python: 2.7.16 not in '>=3'
```